### PR TITLE
Value should be optional and inherited from InputProps

### DIFF
--- a/src/MaskInput.types.ts
+++ b/src/MaskInput.types.ts
@@ -9,9 +9,9 @@ export interface MaskInputProps extends Omit<TextInputProps, 'onChangeText'> {
   mask?: Mask;
 
   /**
-   * Required value for the controlled text input.
+   * Value for the controlled text input.
    */
-  value: string;
+  value?: string;
 
   /**
    * Callback that is called when the text input's text changes.

--- a/src/MaskInput.types.ts
+++ b/src/MaskInput.types.ts
@@ -9,11 +9,6 @@ export interface MaskInputProps extends Omit<TextInputProps, 'onChangeText'> {
   mask?: Mask;
 
   /**
-   * Value for the controlled text input.
-   */
-  value?: string;
-
-  /**
    * Callback that is called when the text input's text changes.
    * @param masked Masked text
    * @param unmasked Unmasked text


### PR DESCRIPTION
Motivation:
Since react native `TextInput` component [could contain undefined value](https://github.com/facebook/react-native/blob/main/Libraries/Components/TextInput/TextInput.d.ts#L772), there's no actual reason to keep value as required field. [Anyway library checks if value exist](https://github.com/CaioQuirinoMedeiros/react-native-mask-input/blob/main/src/MaskInput.tsx#L28) and if it not exist - replaces this with empty string.
It might be misunderstanding in types when using 3rd party libraries that controls inputs, like `react-hook-form` or `formik`.
Please, consider to make this value optional for keeping `MaskedInput` consistent and inherit `InputProps` from react-native correctly